### PR TITLE
Fix missing division sign in sunxi_gfx.c

### DIFF
--- a/gfx/drivers/sunxi_gfx.c
+++ b/gfx/drivers/sunxi_gfx.c
@@ -418,7 +418,7 @@ static sunxi_disp_t *sunxi_disp_init(const char *device)
       (ctx->xres * ctx->bits_per_pixel / 8);
    ctx->gfx_layer_size     = ctx->xres * ctx->yres * fb_var.bits_per_pixel / 8;
    ctx->refresh_rate       = 1000000.0f / fb_var.pixclock * 1000000.0f /
-      (fb_var.yres + fb_var.upper_margin + fb_var.lower_margin + fb_var.vsync_len)
+      (fb_var.yres + fb_var.upper_margin + fb_var.lower_margin + fb_var.vsync_len) /
       (fb_var.xres + fb_var.left_margin  + fb_var.right_margin + fb_var.hsync_len);
 
    if (ctx->framebuffer_size < ctx->gfx_layer_size)


### PR DESCRIPTION
Same fix that [mali_fbdev_ctx.c received](https://github.com/libretro/RetroArch/commit/71c031099b3c39ba1f800889b6fcc9d8c955adb5) for the same problem, just in a different file.

## Description

Was working to see if I could improve performance on H2+ by using the sunxi driver with help from the [sunxi-mali](https://github.com/mripard/sunxi-mali) fbdev kernel driver. This is a simple fix to resolve a type that prevents sunxi_gfx.c from building.

## Related Issues

Was able to find [this commit](https://github.com/libretro/RetroArch/commit/71c031099b3c39ba1f800889b6fcc9d8c955adb5) which fixed it on the mali fbdev side, but was unable to find if there was an issue related to it.

## Related Pull Requests

Was also unable to find if the above commit had a PR associated with it.

## Reviewers

[If possible @mention all the people that should review your pull request]
